### PR TITLE
Use BaseUrl, expect, locator

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {},
   "keywords": [],
-  "author": "",
+  "author": "Lyudmyla Kalmykova",
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.25.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'https://grinfer.com/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/tests/Selectors.spec.ts
+++ b/tests/Selectors.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has Grinfer in title and get started link linking to the intro page', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Grinfer/);
+  const getStarted = page.locator('text=Log In');
+  await expect(getStarted).toHaveAttribute('href', '/sign-in');
+  await getStarted.click();
+  await expect(page).toHaveURL(/.*sign-in/);
+});


### PR DESCRIPTION
Opening a page at the address from the config. Navigate to another page using the locator. Expected result by Titel and Attribute.